### PR TITLE
Bump log4j2.version from 2.11.1 to 2.13.3 (#1529)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <junit.jupiter.version>5.0.0-M4</junit.jupiter.version>
         <junit.platform.version>1.0.0-M4</junit.platform.version>
-        <log4j2.version>2.11.1</log4j2.version>
+        <log4j2.version>2.13.3</log4j2.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jline.version>3.9.0</jline.version>
     </properties>


### PR DESCRIPTION
Bumps `log4j2.version` from 2.11.1 to 2.13.3.

Updates `log4j-api` from 2.11.1 to 2.13.3

Updates `log4j-core` from 2.11.1 to 2.13.3

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>